### PR TITLE
Optimize tag template retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Scrub
-
+## v0.1.1
+- Optimize code to only request structure templates upon initial connection to PLC
 ## v0.1.0
 
 Initial Release

--- a/lib/scrub.ex
+++ b/lib/scrub.ex
@@ -17,15 +17,16 @@ defmodule Scrub do
   # def open_conn(host) when is_binary(host), do: open_session!(host) |> open_conn()
   def open_conn(session) do
     payload = ConnectionManager.encode_service(:large_forward_open)
-    with {:ok, resp} <- Session.send_rr_data(session, payload),
-      {:ok, conn} <- ConnectionManager.decode(resp) do
 
+    with {:ok, resp} <- Session.send_rr_data(session, payload),
+         {:ok, conn} <- ConnectionManager.decode(resp) do
       {session, conn}
     end
   end
 
   def close_conn({session, conn}) do
     payload = ConnectionManager.encode_service(:forward_close, conn: conn)
+
     with {:ok, resp} <- Session.send_rr_data(session, payload) do
       ConnectionManager.decode(resp)
     end
@@ -37,7 +38,7 @@ defmodule Scrub do
 
   def read_tag(session, tag) when is_binary(tag) do
     with {:ok, tag} <- Session.get_tag_metadata(session, tag) do
-      IO.inspect tag
+      IO.inspect(tag)
       read_tag(session, tag)
     end
   end
@@ -46,26 +47,30 @@ defmodule Scrub do
     with {session, conn} <- open_conn(session),
          data <- ConnectionManager.encode_service(:unconnected_send, request_path: tag.name),
          {:ok, resp} <- Session.send_unit_data(session, conn, data) do
-
       close_conn({session, conn})
       ConnectionManager.decode(resp, template)
     end
   end
-  def read_tag(session, %{array_dims: dims, array_length: [h | t]} = tag) when dims > 0 do
-    elements = Enum.reduce(t, h, & &1 * &2)
-    with {session, conn} <- open_conn(session),
-         data <- ConnectionManager.encode_service(:unconnected_send, request_path: tag.name, read_elements: elements),
-         {:ok, resp} <- Session.send_unit_data(session, conn, data) do
 
+  def read_tag(session, %{array_dims: dims, array_length: [h | t]} = tag) when dims > 0 do
+    elements = Enum.reduce(t, h, &(&1 * &2))
+
+    with {session, conn} <- open_conn(session),
+         data <-
+           ConnectionManager.encode_service(:unconnected_send,
+             request_path: tag.name,
+             read_elements: elements
+           ),
+         {:ok, resp} <- Session.send_unit_data(session, conn, data) do
       close_conn({session, conn})
       ConnectionManager.decode(resp, tag)
     end
   end
+
   def read_tag(session, %{} = tag) do
     with {session, conn} <- open_conn(session),
          data <- ConnectionManager.encode_service(:unconnected_send, request_path: tag.name),
          {:ok, resp} <- Session.send_unit_data(session, conn, data) do
-
       close_conn({session, conn})
       ConnectionManager.decode(resp)
     end

--- a/lib/scrub/cip.ex
+++ b/lib/scrub/cip.ex
@@ -2,5 +2,4 @@ defmodule Scrub.CIP do
   def status_code(0x00), do: :success
   def status_code(0x06), do: :too_much_data
   def status_code(status), do: status
-
 end

--- a/lib/scrub/cip/connection.ex
+++ b/lib/scrub/cip/connection.ex
@@ -1,9 +1,7 @@
 defmodule Scrub.CIP.Connection do
-  defstruct [
-    serial: nil,
-    orig_network_id: nil,
-    target_network_id: nil,
-    orig_api: nil,
-    target_api: nil
-  ]
+  defstruct serial: nil,
+            orig_network_id: nil,
+            target_network_id: nil,
+            orig_api: nil,
+            target_api: nil
 end

--- a/lib/scrub/cip/connection_manager.ex
+++ b/lib/scrub/cip/connection_manager.ex
@@ -65,12 +65,16 @@ defmodule Scrub.CIP.ConnectionManager do
         target_network_conn_params::binary(4, 8),
         transport_class_trigger::binary(1),
         # Connection path to Message Router
-        0x03, # size
-        0x01, # seg 1
+        # size
+        0x03,
+        # seg 1
+        0x01,
         0x00,
-        0x20, # seg 2
+        # seg 2
+        0x20,
         0x02,
-        0x24, # seg 3
+        # seg 3
+        0x24,
         0x01
       >>
   end
@@ -98,7 +102,8 @@ defmodule Scrub.CIP.ConnectionManager do
 
         # # Connection path to Message Router
         0x03::usint,
-        0::usint, # Reserved
+        # Reserved
+        0::usint,
         0x01,
         0x00,
         0x20,
@@ -120,7 +125,7 @@ defmodule Scrub.CIP.ConnectionManager do
       end
 
     request_path_padded = <<request_path::binary, 0x00::size(request_path_padding)-unit(8)>>
-    request_path = <<0x91, byte_size(request_path) :: usint, request_path_padded :: binary>>
+    request_path = <<0x91, byte_size(request_path)::usint, request_path_padded::binary>>
 
     request_words = (byte_size(request_path) / 2) |> floor
     read_elements = opts[:read_elements] || 1
@@ -130,11 +135,14 @@ defmodule Scrub.CIP.ConnectionManager do
       Keyword.get(@services, :unconnected_send)::size(7),
       request_words::usint,
       request_path::binary,
-      read_elements :: ulint
+      read_elements::ulint
     >>
   end
 
-  def decode(<<1::size(1), service::size(7), 0, status_code::usint, size::usint, data::binary>>, template_or_tag \\ nil) do
+  def decode(
+        <<1::size(1), service::size(7), 0, status_code::usint, size::usint, data::binary>>,
+        template_or_tag \\ nil
+      ) do
     <<service>> = <<0::size(1), service::size(7)>>
 
     header = %{
@@ -152,36 +160,44 @@ defmodule Scrub.CIP.ConnectionManager do
   end
 
   # Large Forward Open
-  defp decode_service(:large_forward_open, _header, <<
-         orig_network_id::binary(4, 8),
-         target_network_id::binary(4, 8),
-         conn_serial::binary(2, 8),
-         _orig_vendor_id::uint,
-         _orig_serial::udint,
-         orig_api::udint,
-         target_api::udint,
-         0::usint,
-         _reserved::binary
-       >>, _t) do
-
-    {:ok, %Connection{
-      orig_network_id: orig_network_id,
-      target_network_id: target_network_id,
-      serial: conn_serial,
-      orig_api: orig_api,
-      target_api: target_api
-    }}
+  defp decode_service(
+         :large_forward_open,
+         _header,
+         <<
+           orig_network_id::binary(4, 8),
+           target_network_id::binary(4, 8),
+           conn_serial::binary(2, 8),
+           _orig_vendor_id::uint,
+           _orig_serial::udint,
+           orig_api::udint,
+           target_api::udint,
+           0::usint,
+           _reserved::binary
+         >>,
+         _t
+       ) do
+    {:ok,
+     %Connection{
+       orig_network_id: orig_network_id,
+       target_network_id: target_network_id,
+       serial: conn_serial,
+       orig_api: orig_api,
+       target_api: target_api
+     }}
   end
 
   defp decode_service(:forward_close, _header, data, _t) do
-
     {:ok, data}
   end
 
-  defp decode_service(:unconnected_send, %{size: _size}, <<
-         data::binary
-       >>, template) do
-
+  defp decode_service(
+         :unconnected_send,
+         %{size: _size},
+         <<
+           data::binary
+         >>,
+         template
+       ) do
     {:ok, Type.decode(data, template)}
   end
 

--- a/lib/scrub/cip/type.ex
+++ b/lib/scrub/cip/type.ex
@@ -42,7 +42,7 @@ defmodule Scrub.CIP.Type do
   def decode_type(_type, <<>>, [acc]), do: acc
   def decode_type(_type, <<>>, [_ | _] = acc), do: Enum.reverse(acc)
   def decode_type(type, data, acc) do
-    {value, tail} = decode_type_data(type,:binary.copy(data))
+    {value, tail} = decode_type_data(type, data)
     decode_type(type, tail, [value | acc])
   end
 
@@ -62,7 +62,7 @@ defmodule Scrub.CIP.Type do
   def decode_type_data(:lreal, <<value::lreal, tail :: binary>>), do: {value, tail}
   def decode_type_data(:string, <<length::udint, value :: binary(length, 8), tail :: binary>>), do: {value, tail}
 
-  def decode_type_data(:dword, <<value :: binary(4, 8), tail :: binary()>>), do: {value, tail}
+  def decode_type_data(:dword, <<value :: binary(4, 8), tail :: binary()>>), do: {:binary.copy(value), tail}
   def decode_type_data(_, <<0x00::uint, tail :: binary>>), do: {nil, tail}
   def decode_type_data(_type, data), do: {data, <<>>}
 end

--- a/lib/scrub/cip/type.ex
+++ b/lib/scrub/cip/type.ex
@@ -42,7 +42,7 @@ defmodule Scrub.CIP.Type do
   def decode_type(_type, <<>>, [acc]), do: acc
   def decode_type(_type, <<>>, [_ | _] = acc), do: Enum.reverse(acc)
   def decode_type(type, data, acc) do
-    {value, tail} = decode_type_data(type, data)
+    {value, tail} = decode_type_data(type,:binary.copy(data))
     decode_type(type, tail, [value | acc])
   end
 

--- a/lib/scrub/cip/type.ex
+++ b/lib/scrub/cip/type.ex
@@ -3,37 +3,42 @@ defmodule Scrub.CIP.Type do
 
   alias Scrub.CIP.Symbol
 
-  def decode(<<0xA0, 0x02, _crc :: uint, data :: binary>>, %{members: members} = structure) do
-    IO.puts "Template: #{structure.template_name}"
-    IO.inspect structure
+  def decode(<<0xA0, 0x02, _crc::uint, data::binary>>, %{members: members} = structure) do
+    IO.puts("Template: #{structure.template_name}")
+    IO.inspect(structure)
+
     Enum.reduce(members, [], fn
-      %{name: <<"ZZZZZZZZZ", _tail :: binary>>}, acc -> acc
+      %{name: <<"ZZZZZZZZZ", _tail::binary>>}, acc ->
+        acc
+
       %{type: :bool, offset: offset, bit_location: location} = member, acc ->
-        <<_offset :: binary(offset, 8), host :: binary(1, 8), _tail :: binary>> = data
+        <<_offset::binary(offset, 8), host::binary(1, 8), _tail::binary>> = data
         offset = 7 - location
-        <<_offset :: binary(offset, 1), value :: binary(1, 1), _pad :: binary(location, 1)>> = host
+        <<_offset::binary(offset, 1), value::binary(1, 1), _pad::binary(location, 1)>> = host
         {value, _} = decode_type_data(:bool, value)
         [Map.put(member, :value, value) | acc]
 
       %{type: type, offset: offset, array_length: 0} = member, acc ->
-        IO.inspect type
-        <<_offset :: binary(offset, 8), tail :: binary()>> = data
+        IO.inspect(type)
+        <<_offset::binary(offset, 8), tail::binary()>> = data
         {value, _tail} = decode_type_data(type, tail)
         [Map.put(member, :value, value) | acc]
 
       %{type: type, offset: offset, array_length: length} = member, acc ->
-        <<_offset :: binary(offset, 8), data :: binary()>> = data
-          {values, _} =
-            Enum.reduce(1..length, {[], data}, fn(_, {values, data}) ->
-              {value, data} = decode_type_data(type, data)
-              {[value | values], data}
-            end)
+        <<_offset::binary(offset, 8), data::binary()>> = data
+
+        {values, _} =
+          Enum.reduce(1..length, {[], data}, fn _, {values, data} ->
+            {value, data} = decode_type_data(type, data)
+            {[value | values], data}
+          end)
+
         [Map.put(member, :value, values) | acc]
     end)
     |> Enum.reverse()
   end
 
-  def decode(<<type :: binary(2, 8), data :: binary()>>, _t) do
+  def decode(<<type::binary(2, 8), data::binary()>>, _t) do
     Symbol.type_decode(type)
     |> decode_type(data)
   end
@@ -41,28 +46,33 @@ defmodule Scrub.CIP.Type do
   def decode_type(_, _, _ \\ [])
   def decode_type(_type, <<>>, [acc]), do: acc
   def decode_type(_type, <<>>, [_ | _] = acc), do: Enum.reverse(acc)
+
   def decode_type(type, data, acc) do
     {value, tail} = decode_type_data(type, data)
     decode_type(type, tail, [value | acc])
   end
 
-  def decode_type_data(:bool, <<0x01, tail :: binary>>), do: {true, tail}
-  def decode_type_data(:bool, <<0x00, tail :: binary>>), do: {false, tail}
-  def decode_type_data(:bool, <<1 :: size(1), tail :: binary>>), do: {true, tail}
-  def decode_type_data(:bool, <<0 :: size(1), tail :: binary>>), do: {false, tail}
-  def decode_type_data(:int, <<value :: int, tail :: binary>>), do: {value, tail}
-  def decode_type_data(:sint, <<value :: sint, tail :: binary>>), do: {value, tail}
-  def decode_type_data(:dint, <<value :: dint, tail :: binary>>), do: {value, tail}
-  def decode_type_data(:lint, <<value :: lint, tail :: binary>>), do: {value, tail}
-  def decode_type_data(:usint, <<value :: usint, tail :: binary>>), do: {value, tail}
-  def decode_type_data(:uint, <<value :: uint, tail :: binary>>), do: {value, tail}
-  def decode_type_data(:udint, <<value :: udint, tail :: binary>>), do: {value, tail}
-  def decode_type_data(:ulint, <<value :: ulint, tail :: binary>>), do: {value, tail}
-  def decode_type_data(:real, <<value::real, tail :: binary>>), do: {value, tail}
-  def decode_type_data(:lreal, <<value::lreal, tail :: binary>>), do: {value, tail}
-  def decode_type_data(:string, <<length::udint, value :: binary(length, 8), tail :: binary>>), do: {value, tail}
+  def decode_type_data(:bool, <<0x01, tail::binary>>), do: {true, tail}
+  def decode_type_data(:bool, <<0x00, tail::binary>>), do: {false, tail}
+  def decode_type_data(:bool, <<1::size(1), tail::binary>>), do: {true, tail}
+  def decode_type_data(:bool, <<0::size(1), tail::binary>>), do: {false, tail}
+  def decode_type_data(:int, <<value::int, tail::binary>>), do: {value, tail}
+  def decode_type_data(:sint, <<value::sint, tail::binary>>), do: {value, tail}
+  def decode_type_data(:dint, <<value::dint, tail::binary>>), do: {value, tail}
+  def decode_type_data(:lint, <<value::lint, tail::binary>>), do: {value, tail}
+  def decode_type_data(:usint, <<value::usint, tail::binary>>), do: {value, tail}
+  def decode_type_data(:uint, <<value::uint, tail::binary>>), do: {value, tail}
+  def decode_type_data(:udint, <<value::udint, tail::binary>>), do: {value, tail}
+  def decode_type_data(:ulint, <<value::ulint, tail::binary>>), do: {value, tail}
+  def decode_type_data(:real, <<value::real, tail::binary>>), do: {value, tail}
+  def decode_type_data(:lreal, <<value::lreal, tail::binary>>), do: {value, tail}
 
-  def decode_type_data(:dword, <<value :: binary(4, 8), tail :: binary()>>), do: {:binary.copy(value), tail}
-  def decode_type_data(_, <<0x00::uint, tail :: binary>>), do: {nil, tail}
+  def decode_type_data(:string, <<length::udint, value::binary(length, 8), tail::binary>>),
+    do: {value, tail}
+
+  def decode_type_data(:dword, <<value::binary(4, 8), tail::binary()>>),
+    do: {:binary.copy(value), tail}
+
+  def decode_type_data(_, <<0x00::uint, tail::binary>>), do: {nil, tail}
   def decode_type_data(_type, data), do: {data, <<>>}
 end

--- a/lib/scrub/session.ex
+++ b/lib/scrub/session.ex
@@ -220,10 +220,8 @@ defmodule Scrub.Session do
     IO.inspect length(tags)
     case Enum.any?(tags, fn(item) -> Map.has_key?(item, :template) end) do
       false ->
-        IO.puts "No Data requesting templates"
         do_fetch_structure_templates(s)
       _ ->
-        IO.puts "templates present"
         {:ok, s}
     end
 
@@ -266,7 +264,6 @@ defmodule Scrub.Session do
     end
   end
 
-  defp fetch_structure_templates(s), do: {:ok, s}
 
   defp close_conn(s, conn) do
     with data = ConnectionManager.encode_service(:forward_close, conn: conn),

--- a/lib/scrub/session.ex
+++ b/lib/scrub/session.ex
@@ -182,7 +182,7 @@ defmodule Scrub.Session do
       {:ok, %{s | session_handle: session_handle}}
     else
       error ->
-        IO.puts("Error: #{inspect(error)}")
+        Logger.error("Error: #{inspect(error)}")
         :gen_tcp.close(socket)
         {:backoff, 1000, %{s | socket: nil}}
     end
@@ -205,7 +205,7 @@ defmodule Scrub.Session do
       {:ok, %{s | tag_metadata: tags}}
     else
       error ->
-        IO.puts("Error: #{inspect(error)}")
+        Logger.error("Error: #{inspect(error)}")
         :gen_tcp.close(socket)
         {:backoff, 1000, %{s | socket: nil}}
     end
@@ -264,7 +264,7 @@ defmodule Scrub.Session do
       {:ok, %{s | tag_metadata: tags ++ structures}}
     else
       error ->
-        IO.puts("Error: #{inspect(error)}")
+        Logger.error("Error: #{inspect(error)}")
         :gen_tcp.close(socket)
         {:backoff, 1000, %{s | socket: nil}}
     end
@@ -320,7 +320,7 @@ defmodule Scrub.Session do
     case Symbol.decode(binary_resp) do
       {:ok, %{status: :too_much_data, tags: new_tags}} ->
         [%{instance_id: id} | _] = Enum.sort(new_tags, &(&1.instance_id > &2.instance_id))
-        IO.inspect(id)
+        Logger.debug("tag id #{inspect(id)}")
 
         data = Symbol.encode_service(:get_instance_attribute_list, instance_id: id + 1)
         s = do_send_unit_data(s, conn, data)

--- a/lib/scrub/session.ex
+++ b/lib/scrub/session.ex
@@ -9,7 +9,7 @@ defmodule Scrub.Session do
 
   @default_port 44818
 
-  def start_link(host, port \\ @default_port, socket_opts \\ [], timeout \\ 5000)
+  def start_link(host, port \\ @default_port, socket_opts \\ [], timeout \\ 15000)
 
   def start_link(host, port, socket_opts, timeout) when is_binary(host) do
     start_link(ip_to_tuple!(host), port, socket_opts, timeout)

--- a/lib/scrub/session/protocol.ex
+++ b/lib/scrub/session/protocol.ex
@@ -73,7 +73,13 @@ defmodule Scrub.Session.Protocol do
   @doc """
   2-4.8 SendUnitData
   """
-  def send_unit_data(session_handle, %Connection{orig_network_id: network_id}, sequence_number, payload, timeout \\ 65_535) do
+  def send_unit_data(
+        session_handle,
+        %Connection{orig_network_id: network_id},
+        sequence_number,
+        payload,
+        timeout \\ 65_535
+      ) do
     data = <<
       0x00::udint,
       timeout::uint,
@@ -101,6 +107,7 @@ defmodule Scrub.Session.Protocol do
     cond do
       byte_size(data) < length ->
         :partial
+
       true ->
         decode(header, data)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Scrub.MixProject do
   def project do
     [
       app: :scrub,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
Why:
The tag template information would grow infinitely as it was getting appended everytime a connection is started
How:
Checking if tag_template information is present in the tag map