### PR TITLE
Bump Release Number to 0.1.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Scrub.MixProject do
   def project do
     [
       app: :scrub,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
Why:
With the migration to DBConnection a release # change is required to match
changelog