### PR TITLE
Basic Functionality Test Suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ Reading from a tag can be summarized by:
 iex> {:ok, session} = Scrub.open_session("20.0.0.70")
 iex> {:ok, value} = Scrub.read_tag(session,"All_EStops_OK_to_Run")
 ```
+
+### Running Tests
+
+```bash
+$ mix test
+```

--- a/lib/scrub.ex
+++ b/lib/scrub.ex
@@ -21,7 +21,9 @@ defmodule Scrub do
       {session, conn}
     end
   end
-
+  def check_conn_status(session) do
+    Session.status(session)
+  end
   def close_conn({session, conn}) do
     payload = ConnectionManager.encode_service(:forward_close, conn: conn)
 

--- a/lib/scrub/session.ex
+++ b/lib/scrub/session.ex
@@ -106,6 +106,10 @@ defmodule Scrub.Session do
     end
   end
 
+  def status(session) do
+    DBConnection.status(session)
+  end
+
   # DBConnection behaviour
 
   @impl true
@@ -148,6 +152,7 @@ defmodule Scrub.Session do
       {:ok, state}
     end
   end
+
 
   @impl true
   def handle_begin(_opts, state) do

--- a/lib/scrub/session.ex
+++ b/lib/scrub/session.ex
@@ -283,8 +283,7 @@ defmodule Scrub.Session do
 
   @impl true
   def handle_close(%Query{query: :close} = _query, _opts, state) do
-    resp = unregister_session(state)
-    IO.inspect(resp: resp)
+    _resp = unregister_session(state)
     {:ok, nil, state}
   end
 

--- a/test/scrub_test.exs
+++ b/test/scrub_test.exs
@@ -1,4 +1,39 @@
 defmodule ScrubTest do
   use ExUnit.Case
+  alias Scrub.CIP.Connection
+
   doctest Scrub
+  use ExUnit.Case, async: false
+  setup_all do
+    {:ok, session} =
+      Scrub.open_session("20.0.0.70")
+      :ok = wait_for_session(session)
+    %{session: session}
+  end
+
+  test "can open a connection", %{session: session} do
+    assert {_, %Connection{ }} = Scrub.open_conn(session)
+  end
+
+  test "can receive retrieve a tag", %{session: session} do
+    assert {:ok, _} = Scrub.read_tag(session,"P1_HMI_INK_DINT_ARRAY3")
+  end
+
+
+  test "can close a session", %{session: _} do
+    {:ok, session} =
+      Scrub.open_session("20.0.0.70")
+      :ok = wait_for_session(session)
+    assert {:ok, _ } = Scrub.close_session(session)
+
+  end
+
+
+  defp wait_for_session(session) do
+    case Scrub.check_conn_status(session) do
+      :error -> wait_for_session(session)
+      :idle ->
+        :ok
+    end
+  end
 end

--- a/test/scrub_test.exs
+++ b/test/scrub_test.exs
@@ -2,27 +2,31 @@ defmodule ScrubTest do
   use ExUnit.Case
   alias Scrub.CIP.Connection
 
-  doctest Scrub
-  use ExUnit.Case, async: false
-  setup_all do
-    {:ok, session} =
-      Scrub.open_session("20.0.0.70")
-      :ok = wait_for_session(session)
-    %{session: session}
-  end
 
-  test "can open a connection", %{session: session} do
+  doctest Scrub
+  @plc_address "20.0.0.70"
+
+
+  @tag :with_plc
+  test "can open a connection" do
+    {:ok, session} =
+      Scrub.open_session(@plc_address)
+    :ok = wait_for_session(session)
     assert {_, %Connection{ }} = Scrub.open_conn(session)
   end
 
-  test "can receive retrieve a tag", %{session: session} do
+  @tag :with_plc
+  test "can receive retrieve a tag" do
+    {:ok, session} =
+      Scrub.open_session(@plc_address)
+    :ok = wait_for_session(session)
     assert {:ok, _} = Scrub.read_tag(session,"P1_HMI_INK_DINT_ARRAY3")
   end
 
-
-  test "can close a session", %{session: _} do
+  @tag :with_plc
+  test "can close a session" do
     {:ok, session} =
-      Scrub.open_session("20.0.0.70")
+      Scrub.open_session(@plc_address)
       :ok = wait_for_session(session)
     assert {:ok, _ } = Scrub.close_session(session)
 


### PR DESCRIPTION
### Why:
In order to provide a test that confirm a basic PLC comms functionality
### How:
Adding tests that confirm Open connection, tag retrieval and close connection functionality