### PR TITLE
Modify Default Forward Open Mode from client to server

### DIFF
--- a/lib/scrub/cip/connection_manager.ex
+++ b/lib/scrub/cip/connection_manager.ex
@@ -235,7 +235,7 @@ defmodule Scrub.CIP.ConnectionManager do
   end
 
   defp transport_class_trigger(opts \\ []) do
-    dir = opts[:dir] || :client
+    dir = opts[:dir] || :server
     trigger = opts[:trigger] || :application_object
     transport_class = opts[:transport_class] || 3
 


### PR DESCRIPTION
WHY
------
Client mode appears to work only on ControlLogix PLCs.

HOW
------
Based on findings using rxLink, we determined that "server" mode for the Large Forward Open works on ControlLogix and CompactLogix PLC models.