### PR TITLE
Increase the power of list member parsing

### DIFF
--- a/lib/scrub/cip/connection_manager.ex
+++ b/lib/scrub/cip/connection_manager.ex
@@ -143,6 +143,10 @@ defmodule Scrub.CIP.ConnectionManager do
     <<0x91, byte_size(request_path)::usint, request_path_padded::binary>>
   end
 
+  def encode_request_path(request_path) when is_integer(request_path) do
+    <<0x28, request_path::size(8)>>
+  end
+
   def encode_request_path(request_path) when is_list(request_path) do
     Enum.reduce(request_path, <<>>, fn member, acc ->
       <<acc::binary, encode_request_path(member)::binary>>
@@ -208,7 +212,10 @@ defmodule Scrub.CIP.ConnectionManager do
          >>,
          template
        ) do
-    {:ok, Type.decode(data, template)}
+    case Type.decode(data, template) do
+      :invalid -> {:error, :invalid}
+      value -> {:ok, value}
+    end
   end
 
   defp large_forward_open_network_parameters(opts \\ []) do

--- a/lib/scrub/cip/symbol.ex
+++ b/lib/scrub/cip/symbol.ex
@@ -112,7 +112,6 @@ defmodule Scrub.CIP.Symbol do
 
   def filter(tags) when is_list(tags) do
     tags
-    |> Enum.reject(&String.contains?(&1.name, ":"))
     |> Enum.reject(&filter_structure/1)
   end
 

--- a/lib/scrub/cip/type.ex
+++ b/lib/scrub/cip/type.ex
@@ -43,6 +43,10 @@ defmodule Scrub.CIP.Type do
     |> decode_type(data)
   end
 
+  def decode("", _t) do
+    :invalid
+  end
+
   def decode_type(_, _, _ \\ [])
   def decode_type(_type, <<>>, [acc]), do: acc
   def decode_type(_type, <<>>, [_ | _] = acc), do: Enum.reverse(acc)


### PR DESCRIPTION
WHY
-----
Users want to parse Array members individually, as well as potentially retrieve multiple levels deep of multi-dim arrays and arrays of structs, etc

HOW
----

- Implement an ordered list approach to request path building. 
-- ex: "Struct.Member[2].deep_struct_member"  ->  ["Struct", "Member", 2, "deep_struct_member"]

- Improve upon decoding so that if a member is invalid or unrequestable an :error :invalid is returned.