### PR TITLE
Handle read errors

### DIFF
--- a/lib/scrub/cip.ex
+++ b/lib/scrub/cip.ex
@@ -1,5 +1,6 @@
 defmodule Scrub.CIP do
   def status_code(0x00), do: :success
   def status_code(0x06), do: :too_much_data
+  def status_code(0x0F), do: :privilage_violation
   def status_code(status), do: status
 end

--- a/lib/scrub/cip.ex
+++ b/lib/scrub/cip.ex
@@ -1,6 +1,6 @@
 defmodule Scrub.CIP do
   def status_code(0x00), do: :success
   def status_code(0x06), do: :too_much_data
-  def status_code(0x0F), do: :privilage_violation
+  def status_code(0x0F), do: :privilege_violation
   def status_code(status), do: status
 end

--- a/lib/scrub/cip/connection_manager.ex
+++ b/lib/scrub/cip/connection_manager.ex
@@ -202,13 +202,22 @@ defmodule Scrub.CIP.ConnectionManager do
 
   defp decode_service(
          :unconnected_send,
-         %{size: _size},
+         %{status_code: :success},
          <<
            data::binary
          >>,
          template
        ) do
     {:ok, Type.decode(data, template)}
+  end
+
+  defp decode_service(
+         _,
+         %{status_code: code},
+         _,
+         _
+       ) do
+    {:error, code}
   end
 
   defp large_forward_open_network_parameters(opts \\ []) do


### PR DESCRIPTION
WHY
-----
When tags dont get read properly, decode returns a blank string and :ok This is problematic down the pipe as users think the tag is just blank

HOW
-----
Return {:error, code} similar to other returns. i.e. {:error, :no_tag_found} or {:error, :privilage_violation}
This will also return other error codes that have yet to be added to the list of known codes