### PR TITLE
Add important return codes, and remove filter of vendor specific

### DIFF
--- a/lib/scrub.ex
+++ b/lib/scrub.ex
@@ -41,7 +41,7 @@ defmodule Scrub do
   def read_metadata(session) do
     case Session.get_tags_metadata(session) do
       {:ok, metadata} ->
-        {:ok, format_tags(metadata)}
+        {:ok, metadata}
 
       error ->
         error
@@ -112,23 +112,6 @@ defmodule Scrub do
       ConnectionManager.decode(resp)
     end
   end
-
-  def format_tags(tags) do
-    tags
-    |> Enum.map(&format/1)
-    |> List.flatten
-    |> Enum.reject(&is_nil/1)
-  end
-
-
-  def format(%{name: name, structure: :structured, template: %{members: members}}) do
-    {name, :structure, Enum.flat_map(members, fn(%{name: member_name, type: type}) -> if is_atom(type) && !String.contains?(member_name, ["__", "ZZZZZZZZZZ"]), do: [{member_name, type}], else: [] end)}
-  end
-
-  def format(%{name: name, structure: :atomic, type: type, array_dims: 0}), do: {name, type, []}
-  def format(%{name: name, structure: :atomic, type: type, array_length: [len] }), do: {name, type, [len]}
-  def format(%{name: name, structure: :system}), do: {name, :system}
-  def format(_), do: nil
 
   # def read_tag(host, tag) when is_binary(host) do
   #   open_conn(host)

--- a/lib/scrub/cip.ex
+++ b/lib/scrub/cip.ex
@@ -1,6 +1,11 @@
 defmodule Scrub.CIP do
   def status_code(0x00), do: :success
+  def status_code(0x03), do: :invalid_parameter
+  def status_code(0x04), do: :path_segment_error
+  def status_code(0x05), do: :path_unknown
   def status_code(0x06), do: :too_much_data
+  def status_code(0x0A), do: :get_attribute_error
+  def status_code(0x11), do: :too_much_data_failure
   def status_code(0x0F), do: :privilege_violation
   def status_code(status), do: status
 end

--- a/lib/scrub/cip/symbol.ex
+++ b/lib/scrub/cip/symbol.ex
@@ -119,11 +119,6 @@ defmodule Scrub.CIP.Symbol do
   def filter_structure(%{structure: :system}), do: true
   def filter_structure(%{name: <<"__", _tail::binary>>}), do: true
 
-  def filter_structure(%{structure: :structured, template_instance: instance}) do
-    <<instance::uint>> = instance
-    instance not in 0x100..0xEFF
-  end
-
   def filter_structure(_), do: false
 
   # Anything that is not a _, 0x00 is assumed to be an array


### PR DESCRIPTION
WHY
-----
Machines will use Vendor Specific Structs to provide useful data

HOW
-----
Allow these structs to be populated in the Scrub DB for access later