### PR TITLE
Bulk tag read

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ iex> {:ok, session} = Scrub.open_session("20.0.0.70")
 iex> {:ok, value} = Scrub.read_tag(session,"All_EStops_OK_to_Run")
 ```
 
+Reading Structure member -  Struct.Member_name[3]
+```elixir
+iex> {:ok, session} = Scrub.open_session("20.0.0.70")
+iex> {:ok, value} = Scrub.read_tag(session,["Struct", "Member_name", 3])
+```
+
+Reading Bulk Tags -  "All_Estops_OK_to_Run" and Struct.Member_name[3]
+```elixir
+iex> {:ok, session} = Scrub.open_session("20.0.0.70")
+iex> {:ok, value} = Scrub.bulk_read_tags(session,["All_Estops_OK_to_Run", ["Struct", "Member_name", 3]])
+```
+
 ### Running Tests
 
 ```bash

--- a/lib/scrub.ex
+++ b/lib/scrub.ex
@@ -74,7 +74,7 @@ defmodule Scrub do
           ConnectionManager.decode(resp)
         end
 
-      {elapsed, {:error, _}} = error ->
+      {:error, _} = error ->
         error
     end
   end

--- a/lib/scrub.ex
+++ b/lib/scrub.ex
@@ -7,7 +7,6 @@ defmodule Scrub do
   alias Scrub.Session
 
   require IEx
-  require Logger
 
   def open_session(host) do
     Scrub.Session.start_link(host)
@@ -52,10 +51,8 @@ defmodule Scrub do
   def bulk_read_tags(session, [_path | _rest] = tag_list) do
     with {session, conn} <- open_conn(session),
          data <- ConnectionManager.encode_service(:multiple_service_request, tag_list: tag_list),
-         {resp_elapsed, {:ok, resp}} <- :timer.tc(&Session.send_unit_data/3, [session, conn, data]) do
-      Logger.debug("== get data took: #{resp_elapsed} microseconds ==")
+         {:ok, resp} <- Session.send_unit_data(session, conn, data) do
       close_conn({session, conn})
-      Logger.debug(" - #{IO.inspect(Base.encode16(resp))}")
       ConnectionManager.decode(resp)
     end
   end
@@ -67,20 +64,17 @@ defmodule Scrub do
   # This is outlined in the request path examples for Logix 5000 Controllers Data Access page 65
   def read_tag(session, [tag | _rest] = nested_member) when is_binary(tag) do
     # ensure tag metadata is valid
-    case :timer.tc(&Session.get_tag_metadata/2, [session, tag]) do
-      {elapsed, {:ok, _}} ->
-        Logger.debug("== get meta for #{tag} took: #{elapsed} microseconds ==")
+    case Session.get_tag_metadata(session, tag) do
+      {:ok, _} ->
         with {session, conn} <- open_conn(session),
              data <-
                ConnectionManager.encode_service(:unconnected_send, request_path: nested_member),
-             {resp_elapsed, {:ok, resp}} <- :timer.tc(&Session.send_unit_data/3, [session, conn, data]) do
-          Logger.debug("== get data for #{tag} took: #{resp_elapsed} microseconds ==")
+             {:ok, resp} <- Session.send_unit_data(session, conn, data) do
           close_conn({session, conn})
           ConnectionManager.decode(resp)
         end
 
       {elapsed, {:error, _}} = error ->
-        Logger.debug("== get meta failed for #{tag} in: #{elapsed} microseconds ==")
         error
     end
   end

--- a/lib/scrub/cip.ex
+++ b/lib/scrub/cip.ex
@@ -7,6 +7,7 @@ defmodule Scrub.CIP do
   def status_code(0x0A), do: :get_attribute_error
   def status_code(0x11), do: :too_much_data_failure
   def status_code(0x0F), do: :privilege_violation
-  def status_code(0x1E), do: :embedded_service_failure #This happens when one or more services in multiservice fails
+  # This happens when one or more services in multiservice fails
+  def status_code(0x1E), do: :embedded_service_failure
   def status_code(status), do: status
 end

--- a/lib/scrub/cip.ex
+++ b/lib/scrub/cip.ex
@@ -7,5 +7,6 @@ defmodule Scrub.CIP do
   def status_code(0x0A), do: :get_attribute_error
   def status_code(0x11), do: :too_much_data_failure
   def status_code(0x0F), do: :privilege_violation
+  def status_code(0x1E), do: :embedded_service_failure #This happens when one or more services in multiservice fails
   def status_code(status), do: status
 end

--- a/lib/scrub/cip/connection_manager.ex
+++ b/lib/scrub/cip/connection_manager.ex
@@ -267,7 +267,7 @@ defmodule Scrub.CIP.ConnectionManager do
            offset_bin::binary(service_count, 16),
            data::binary
          >>,
-         template
+         _template
        )
        when code in [:success, :embedded_service_failure] do
     # grab offset data


### PR DESCRIPTION
WHY
-----
SUN needs to read large amounts of data every second. Using the OPEN -> READ -> CLOSE method, reads were taking 2 to 3 seconds per chunk of tags. The Mulitple Packet Service can combine all the tag reads into a single request to then be returned to the user. 
NOTE: in testing Helios Nerves, I was able to read 100 tags in less than .1 seconds using the BULK read service

HOW
-----
-Implement an encoder to encode an array of request paths into a single packet.
-Implement a decoder to unwrap the response and return a bulk data packet to the client.
